### PR TITLE
Adding request object from express to getModel call

### DIFF
--- a/src/express-restify-mongoose.js
+++ b/src/express-restify-mongoose.js
@@ -111,7 +111,7 @@ const restify = function (app, model, opts) {
     const getModel = options.modelFactory && options.modelFactory.getModel
 
     req.erm = {
-      model: typeof getModel === 'function' ? getModel() : model,
+      model: typeof getModel === 'function' ? getModel(req) : model,
     }
 
     next()


### PR DESCRIPTION
With the request passed the modelFactory is able to inspect the request and elect the correct tenant.