### PR TITLE
MONGO_URL as alternative to constant value

### DIFF
--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -143,7 +143,8 @@ module.exports = function () {
     }
 
     if (opts.connect) {
-      mongoose.connect('mongodb://localhost/database').then(function () {
+      const uri = process.env.MONGO_URL || 'mongodb://localhost/database'
+      mongoose.connect(uri).then(function () {
         callback()
       })
     } else if (typeof callback === 'function') {


### PR DESCRIPTION
If the environment supplies a MONGO_URL, it takes precedence before the localhost address, so that mongos with authentication or other specific settings configurable by url can be used without switching the database environment.

@Zertz: In fact it is a test setup file. I haven't written a test to test the test setup .... and hope it is ok.